### PR TITLE
Support renumbered T2 capture devices

### DIFF
--- a/ucm2/AppleT2/HiFi-x6.conf
+++ b/ucm2/AppleT2/HiFi-x6.conf
@@ -1,5 +1,22 @@
 Include.pcm_split.File "/common/pcm/split.conf"
 
+# The staging driver traditionally uses capture PCM devices 1 and 3. Some
+# Watanare T2 kernel builds expose the same endpoints as 100 and 101 instead.
+Define.DigitalMicDevice 1
+Define.HeadsetMicDevice 3
+
+If.renumbered_capture_devices {
+	Condition {
+		Type Path
+		Mode read
+		Path "/proc/asound/Audio/pcm100c/sub0/status"
+	}
+	True {
+		Define.DigitalMicDevice 100
+		Define.HeadsetMicDevice 101
+	}
+}
+
 Macro.playback.SplitPCM {
 	Name "apple_t2_speakers"
 	Direction Playback
@@ -58,7 +75,7 @@ SectionDevice."Mic" {
 		CapturePriority 300
 		CaptureChannels 3
 		CaptureRate 48000
-		CapturePCM "hw:${CardId},1"
+		CapturePCM "hw:${CardId},${var:DigitalMicDevice}"
 	}
 }
 
@@ -87,7 +104,7 @@ SectionDevice."Headset" {
 	Value {
 		CapturePriority 200
 		CaptureChannels 1
-		CapturePCM "hw:${CardId},3"
+		CapturePCM "hw:${CardId},${var:HeadsetMicDevice}"
 		JackControl "Codec Output Jack"
 	}
 }


### PR DESCRIPTION
## What changed

Make the AppleT2 x6 UCM profile select capture PCM devices dynamically:

- retain devices `1` and `3` for kernels using the traditional numbering
- select devices `100` and `101` when `/proc/asound/Audio/pcm100c/sub0/status` is present

## Why

Some Watanare T2 kernel builds expose Digital Mic and Codec Input as ALSA devices 100 and 101. The fixed device 1/3 references then fail or capture silence even though the endpoints exist.

## Impact

The same UCM profile works on both observed kernel layouts without maintaining machine-specific copies. Playback configuration is unchanged.

## Validation

- `git diff --check`
- on kernel 7.1.6, `alsaucm dump text` resolved Digital Mic/Headset Mic to `hw:Audio,100` and `hw:Audio,101`
- after downgrading to kernel 7.0.11, the same profile resolved them to `hw:Audio,1` and `hw:Audio,3`
- `arecord -l` confirmed devices 1 and 3 on the downgraded kernel
